### PR TITLE
chore: gen and fix

### DIFF
--- a/assets/2023Fall/index.html
+++ b/assets/2023Fall/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html>
+
+<head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-QKTQQPYBTB"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+
+        gtag('config', 'G-QKTQQPYBTB');
+    </script>
+
+    <meta charset="utf-8" name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="github-markdown.css">
+    <title>template.html</title>
+    <style media="screen" type="text/css">
+        .markdown-body {
+            box-sizing: border-box;
+            min-width: 200px;
+            max-width: 980px;
+            margin: 0 auto;
+            padding: 45px;
+        }
+
+        @media (max-width: 767px) {
+            .markdown-body {
+                padding: 15px;
+            }
+        }
+    </style>
+</head>
+
+<body class="markdown-body">
+    <h1>2022年春，代数拓扑选讲</h1>
+<ul>
+<li>林伟南
+<ul>
+<li>邮件: lwnpku@math.pku.edu.cn</li>
+<li>办公室: 23楼211</li>
+</ul>
+</li>
+<li>上课时间:
+<ul>
+<li>双周四1-2节 (8:00am-9:50am)</li>
+<li>周五7-8节 (3:10pm-5:00pm)</li>
+</ul>
+</li>
+<li>上课地点：三教404</li>
+<li>答疑时间：周五1:00pm-2:00pm 或者邮件预约</li>
+<li>参考文献
+<ul>
+<li>May, A concise course in algebraic topology</li>
+<li>Weibel, Homological algebra</li>
+<li>Goerss-Jardine - Simplicial homotopy theory</li>
+</ul>
+</li>
+<li>课件
+<ul>
+<li><a href="./Lecture1-CofiberSequences.pdf">Lecture1-CofiberSequences.pdf</a></li>
+<li><a href="./Lecture2-FiberSequences.pdf">Lecture2-FiberSequences.pdf</a></li>
+<li><a href="./Lecture3-SimplicialSets.pdf">Lecture3-SimplicialSets.pdf</a></li>
+<li><a href="./Lecture4-SimplicialHomotopy.pdf">Lecture4-SimplicialHomotopy.pdf</a></li>
+<li><a href="./Lecture5-HochschildHomology.pdf">Lecture5-HochschildHomology.pdf</a></li>
+<li><a href="./Lecture6-CyclicHomology.pdf">Lecture6-CyclicHomology.pdf</a></li>
+</ul>
+</li>
+</ul>
+
+</body>

--- a/index.html
+++ b/index.html
@@ -57,11 +57,11 @@
 <tbody>
 <tr>
 <td>Fall 2023</td>
-<td><a href="./assets/2022Fall/index.html">Selected Topics in Algebraic Topology</a></td>
+<td><a href="./assets/2023Fall/index.html">Selected Topics in Algebraic Topology</a></td>
 </tr>
 <tr>
 <td>Spring 2022</td>
-<td><a href="./assets/2023Spring/index.html">Selected Topics in Algebraic Topology</a></td>
+<td><a href="./assets/2022Spring/index.html">Selected Topics in Algebraic Topology</a></td>
 </tr>
 </tbody>
 </table>

--- a/index_.md
+++ b/index_.md
@@ -1,4 +1,4 @@
-# Weinan Lin (林伟南) 
+# Weinan Lin (林伟南)
 ## About Me
 I am currently an instructor in [School of Mathematical Science](http://english.math.pku.edu.cn/), Peking University.
 
@@ -13,14 +13,14 @@ Here is my [research statement](./assets/pdf/Research_Statement.pdf).
 ## Publications and preprints
 * On the May spectral sequence at the prime 2. Advances in Mathematics (2022). [arXiv:2010.14754](https://arxiv.org/abs/2010.14754)
 * Noncommutative Gröbner Bases and Ext groups. Accepted by Peking Mathematical Journal (2023). [arXiv:2304.00506](https://arxiv.org/abs/2304.00506)
-  
+
 ## Teaching
 ### Peking University.
 
 | Semester | Course Name |
 |---|---|
-| Fall 2023 | [Selected Topics in Algebraic Topology](./assets/2022Fall/index.html) |
-| Spring 2022 | [Selected Topics in Algebraic Topology](./assets/2023Spring/index.html) |
+| Fall 2023 | [Selected Topics in Algebraic Topology](./assets/2023Fall/index.html) |
+| Spring 2022 | [Selected Topics in Algebraic Topology](./assets/2022Spring/index.html) |
 
 ### University of Chicago.
 

--- a/task.py
+++ b/task.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """doc"""
 import argparse
 import os


### PR DESCRIPTION
This PR

- generate the missing HTML via `./task.py -f ./assets/2023Fall/index_.md -o ./assets/2023Fall/index.html -t template.html`
- fix links in homepage

but

- the artifacts in 2023Fall is still missing because there is not such files

and

- I can help with improving the automation workflows with CI, like auto regenerate the missing HTMLs, publish to web, and other tasks